### PR TITLE
Add Signing Algorithm selection support to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ below for further info. The takeaway message is that this property value is a co
 
 `auth0.defaultAuth0ApiSecurityEnabled` - This is a boolean value that switches having the default config enabled. Should be `false`
 
+The default JWT Signing Algorithm is `HS256`. This is HMAC SHA256, a symmetric crypographic algorithm (HMAC), that uses the `clientSecret` to
+verify a signed JWT token. However, if you wish to configure this library to use an alternate cryptographic algorithm then use the two
+options below. The Auth0 Dashboard offers the choice between `HS256` and `RS256`. 'RS256' is RSA SHA256 and uses a public key cryptographic
+algorithm (RSA), that requires knowledge of the application public key to verify a signed JWT Token (that was signed with a private key).
+You can download the application's public key from the Auth0 Dashboard and store it inside your application's WEB-INF directory. 
+
+The following two attributes are required when configuring your application with this library to use `RSA` instead of `HMAC`:
+
+`auth0.signing_algorithm` - This is signing algorithm to verify signed JWT token. Use `HS256` or `RS256`. 
+
+`auth0.public_key_path` - This is the path location to the public key stored locally on disk / inside your application War file WEB-INF directory. Should always be set when using `RS256`. 
+
 
 ### Extending Auth0SecurityConfig
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
         </dependency>
 
         <!--third party-->

--- a/src/main/java/com/auth0/spring/security/api/Auth0SecurityConfig.java
+++ b/src/main/java/com/auth0/spring/security/api/Auth0SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.auth0.spring.security.api;
 
+import com.auth0.jwt.Algorithm;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -52,6 +53,18 @@ public class Auth0SecurityConfig extends WebSecurityConfigurerAdapter {
     @Value(value = "${auth0.base64EncodedSecret}")
     protected boolean base64EncodedSecret;
 
+    /**
+     * default to HS256 for backwards compatibility
+     */
+    @Value(value = "${auth0.signingAlgorithm:HS256}")
+    protected String signingAlgorithm;
+
+    /**
+     * default to empty string as HS256 is default
+     */
+    @Value(value = "${auth0.publicKeyPath:}")
+    protected String publicKeyPath;
+
     @Autowired
     @SuppressWarnings("SpringJavaAutowiringInspection")
     @Bean(name = "auth0AuthenticationManager")
@@ -79,6 +92,8 @@ public class Auth0SecurityConfig extends WebSecurityConfigurerAdapter {
         authenticationProvider.setSecuredRoute(securedRoute);
         authenticationProvider.setAuthorityStrategy(authorityStrategy);
         authenticationProvider.setBase64EncodedSecret(base64EncodedSecret);
+        authenticationProvider.setSigningAlgorithm(Algorithm.valueOf(this.signingAlgorithm));
+        authenticationProvider.setPublicKeyPath(this.publicKeyPath);
         return authenticationProvider;
     }
 

--- a/src/main/java/com/auth0/spring/security/api/Auth0TokenHelperImpl.java
+++ b/src/main/java/com/auth0/spring/security/api/Auth0TokenHelperImpl.java
@@ -29,6 +29,8 @@ public class Auth0TokenHelperImpl implements Auth0TokenHelper<Object>, Initializ
             final HashMap<String, Object> claims = new HashMap<>();
             claims.putAll((Map) object);
             claims.put("exp", expiration);
+            claims.put("iss", "YOUR_ISSUER");
+            claims.put("aud", "YOUR_CLIENT_ID");
             final String token = jwtSigner.sign(claims);
             return token;
         } catch (Exception e) {


### PR DESCRIPTION
Currently, only `HS256` support is available. This PR permits the configuration of `RS256` support when used with `Auth0`. The default algorithm remains as `HS256` if no configuration provided, hence backwards compatible and only requires a minor version update when publishing to Maven.