### PR TITLE
Fix null reference exception on missing 'email_verified' attribute.

### DIFF
--- a/src/main/java/com/auth0/spring/security/api/Auth0UserDetails.java
+++ b/src/main/java/com/auth0/spring/security/api/Auth0UserDetails.java
@@ -37,7 +37,7 @@ public class Auth0UserDetails implements UserDetails {
         }
 
         if (map.containsKey("email")) {
-            this.emailVerified = Boolean.valueOf(map.get("email_verified").toString());
+            this.emailVerified = map.containsKey("email_verified") ? Boolean.valueOf(map.get("email_verified").toString()) : false;
         }
         setupGrantedAuthorities(map, authorityStrategy);
     }


### PR DESCRIPTION
Auth0UserDetails expects the presence of the `email_verified` attribute whenever an `email` attribute exists. However, this isn't always the case - for example, when using the "Get email address from Twitter" rule to get a user's email from Twitter, the `email_verified` attribute is missing. Defensive fix - will file a separate service ticket for the rule to properly set `email_verified` attribute as well.