### PR TITLE
Allow a custom Auth0AuthorityStrategy via Spring bean

### DIFF
--- a/src/main/java/com/auth0/spring/security/api/Auth0AuthorityStrategy.java
+++ b/src/main/java/com/auth0/spring/security/api/Auth0AuthorityStrategy.java
@@ -1,39 +1,12 @@
 package com.auth0.spring.security.api;
 
+import java.util.Collection;
+import java.util.Map;
+
 /**
- * The authority strategy being used
- *
- * Would expect three possible types of strategy pertaining to "Role" info:
- * Groups, Roles, and Scope
- *
- * For API Resource Server using JWT Tokens - `scope` is the default
- * Configurable via auth0.properties file
- *
+ * The strategy used to extract "Role" info from the token.
  */
-public enum Auth0AuthorityStrategy {
+public interface Auth0AuthorityStrategy {
 
-    GROUPS("groups"),
-    ROLES("roles"),
-    SCOPE("scope");
-
-    private final String name;
-
-    private Auth0AuthorityStrategy(final String name) {
-        this.name = name;
-    }
-
-    @Override
-    public String toString() {
-        return this.name;
-    }
-
-    public static boolean contains(String value) {
-        for (final Auth0AuthorityStrategy authorityStrategy : Auth0AuthorityStrategy.values()) {
-            if (authorityStrategy.name().equals(value)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
+  Collection<String> getAuthorities(Map<String, Object> map);
 }

--- a/src/main/java/com/auth0/spring/security/api/Auth0AuthorityStrategyType.java
+++ b/src/main/java/com/auth0/spring/security/api/Auth0AuthorityStrategyType.java
@@ -1,0 +1,46 @@
+package com.auth0.spring.security.api;
+
+/**
+ * The built in authority strategy being used
+ *
+ * Three possible types of strategy pertaining to "Role" info are built in:
+ * Groups, Roles, and Scope
+ *
+ * For API Resource Server using JWT Tokens - `scope` is the default
+ * Configurable via auth0.properties file or by providing a custom Auth0AuthorityStrategy
+ * bean
+ *
+ */
+public enum Auth0AuthorityStrategyType {
+
+    GROUPS("groups", new ListAttributeStrategy("groups")),
+    ROLES("roles", new ListAttributeStrategy("roles")),
+    SCOPE("scope", new StringAttributeStrategy("scopes"));
+
+    private final String name;
+    private final Auth0AuthorityStrategy strategy;
+
+    private Auth0AuthorityStrategyType(final String name, final Auth0AuthorityStrategy strategy) {
+        this.name = name;
+        this.strategy = strategy;
+    }
+
+    public Auth0AuthorityStrategy getStrategy() {
+      return this.strategy;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+
+    public static boolean contains(String value) {
+        for (final Auth0AuthorityStrategyType authorityStrategy : values()) {
+            if (authorityStrategy.name().equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/auth0/spring/security/api/Auth0SecurityConfig.java
+++ b/src/main/java/com/auth0/spring/security/api/Auth0SecurityConfig.java
@@ -77,20 +77,25 @@ public class Auth0SecurityConfig extends WebSecurityConfigurerAdapter {
         return new Auth0CORSFilter();
     }
 
-    @Bean(name = "auth0AuthenticationProvider")
-    public Auth0AuthenticationProvider auth0AuthenticationProvider() {
+    @Bean(name = "auth0AuthorityStrategy")
+    public Auth0AuthorityStrategy auth0AuthorityStrategy() {
         // First check the authority strategy configured for the API
-        if (!Auth0AuthorityStrategy.contains(this.authorityStrategy)) {
+        if (!Auth0AuthorityStrategyType.contains(this.authorityStrategy)) {
             throw new IllegalStateException("Configuration error, illegal authority strategy");
         }
-        final Auth0AuthorityStrategy authorityStrategy = Auth0AuthorityStrategy.valueOf(this.authorityStrategy);
+        return Auth0AuthorityStrategyType.valueOf(this.authorityStrategy).getStrategy();
+    }
+
+    @Bean(name = "auth0AuthenticationProvider")
+    public Auth0AuthenticationProvider auth0AuthenticationProvider() {
+
         final Auth0AuthenticationProvider authenticationProvider = new Auth0AuthenticationProvider();
         authenticationProvider.setDomain(domain);
         authenticationProvider.setIssuer(issuer);
         authenticationProvider.setClientId(clientId);
         authenticationProvider.setClientSecret(clientSecret);
         authenticationProvider.setSecuredRoute(securedRoute);
-        authenticationProvider.setAuthorityStrategy(authorityStrategy);
+        authenticationProvider.setAuthorityStrategy(auth0AuthorityStrategy());
         authenticationProvider.setBase64EncodedSecret(base64EncodedSecret);
         authenticationProvider.setSigningAlgorithm(Algorithm.valueOf(this.signingAlgorithm));
         authenticationProvider.setPublicKeyPath(this.publicKeyPath);

--- a/src/main/java/com/auth0/spring/security/api/Auth0UserDetails.java
+++ b/src/main/java/com/auth0/spring/security/api/Auth0UserDetails.java
@@ -44,26 +44,15 @@ public class Auth0UserDetails implements UserDetails {
 
     private void setupGrantedAuthorities(final Map<String, Object> map, final Auth0AuthorityStrategy authorityStrategy) {
         this.authorities = new ArrayList<>();
-        final String authorityStrategyName = authorityStrategy.toString();
-        if (map.containsKey(authorityStrategyName)) {
-            // here, we differentiate between "scope" which is a space delimited string & "roles" and "groups" which are a list
-            try {
-                List<String> authorities = new ArrayList<>();
-                if (Auth0AuthorityStrategy.SCOPE.equals(authorityStrategy)) {
-                    final String authoritiesStr = (String) map.get(authorityStrategyName);
-                    if (authoritiesStr != null) {
-                        authorities = Arrays.asList(authoritiesStr.split("\\s+"));
-                    }
-                } else {
-                    authorities = (ArrayList<String>) map.get(authorityStrategyName);
-                }
-                for (final String authority : authorities) {
+        try {
+            Collection<String> authorities = authorityStrategy.getAuthorities(map);
+            if (authorities != null) {
+                 for (final String authority : authorities) {
                     this.authorities.add(new SimpleGrantedAuthority(authority));
                 }
-            } catch (ClassCastException e) {
-                e.printStackTrace();
-                logger.error("Error in casting the roles object");
             }
+        } catch (Exception e) {
+            logger.error("Error in executing the authority strategy", e);
         }
     }
 

--- a/src/main/java/com/auth0/spring/security/api/ListAttributeStrategy.java
+++ b/src/main/java/com/auth0/spring/security/api/ListAttributeStrategy.java
@@ -1,0 +1,23 @@
+package com.auth0.spring.security.api;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class ListAttributeStrategy implements Auth0AuthorityStrategy {
+
+  private final String attribute;
+
+  public ListAttributeStrategy(String attribute) {
+    if (attribute == null || attribute.isEmpty()) {
+      throw new IllegalArgumentException("Attribute must be a valid string");
+    }
+    this.attribute = attribute;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Collection<String> getAuthorities(Map<String, Object> map) {
+    return (Collection<String>) map.get(attribute);
+  }
+
+}

--- a/src/main/java/com/auth0/spring/security/api/StringAttributeStrategy.java
+++ b/src/main/java/com/auth0/spring/security/api/StringAttributeStrategy.java
@@ -1,0 +1,27 @@
+package com.auth0.spring.security.api;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+public class StringAttributeStrategy implements Auth0AuthorityStrategy {
+
+  private final String attribute;
+
+  public StringAttributeStrategy(String attribute) {
+    if (attribute == null || attribute.isEmpty()) {
+      throw new IllegalArgumentException("Attribute must be a valid string");
+    }
+    this.attribute = attribute;
+  }
+
+  @Override
+  public Collection<String> getAuthorities(Map<String, Object> map) {
+      final String authoritiesStr = (String) map.get(attribute);
+      if (authoritiesStr != null) {
+          return Arrays.asList(authoritiesStr.split("\\s+"));
+      }
+      return null;
+  }
+
+}


### PR DESCRIPTION
I added support for specifying a custom strategy to extract granted authorities from the token.

This supports:
* manipulating/expanding the authorities of the token
* reading the roles from multiple fields

In our case we need to expand the user role to an exhaustive list of system commands that is both too big and too to hard too maintain on the token itself.

Backward compatibility should still be there.