### PR TITLE
Upgrade java-jwt dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,15 +55,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>2.2.0</version>
-        </dependency>
-
-        <!--third party-->
-
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.4</version>
+            <version>2.2.1</version>
         </dependency>
 
         <!--test-->


### PR DESCRIPTION
Upgrade to java-jwt 2.2.1 that provides a fix for commons-codec dependency version.
Also removed dependency to commons-codec, since it is provided by said java-jwt. Either this or please upgrade to commons-codec 1.10.