### PR TITLE
Use nickname from normalized profile instead of username

### DIFF
--- a/src/main/java/com/auth0/spring/security/api/Auth0UserDetails.java
+++ b/src/main/java/com/auth0/spring/security/api/Auth0UserDetails.java
@@ -27,8 +27,8 @@ public class Auth0UserDetails implements UserDetails {
         this.details = map;
         if (map.containsKey("email")) {
             this.username = map.get("email").toString();
-        } else if (map.containsKey("username")) {
-            this.username = map.get("username").toString();
+        } else if (map.containsKey("nickname")) {
+            this.username = map.get("nickname").toString();
         } else if (map.containsKey("user_id")) {
             this.username = map.get("user_id").toString();
         } else {


### PR DESCRIPTION
The username set in the UserDetails should be from the property "nickname" from the normalized profile https://auth0.com/docs/user-profile/normalized.

Thanks!
