### PR TITLE
Handle JWT that will not decode

### DIFF
--- a/src/main/java/com/auth0/spring/security/api/BearerSecurityContextRepository.java
+++ b/src/main/java/com/auth0/spring/security/api/BearerSecurityContextRepository.java
@@ -1,5 +1,6 @@
 package com.auth0.spring.security.api;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpRequestResponseHolder;
@@ -14,7 +15,11 @@ public class BearerSecurityContextRepository implements SecurityContextRepositor
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         String token = tokenFromRequest(requestResponseHolder.getRequest());
         if (token != null) {
-            context.setAuthentication(new JwtAuthentication(token));
+            try {
+                context.setAuthentication(new JwtAuthentication(token));
+            } catch (JWTVerificationException e) {
+                // no-op, return empty context
+            }
         }
         return context;
     }

--- a/src/test/java/com/auth0/spring/security/api/BearerSecurityContextRepositoryTest.java
+++ b/src/test/java/com/auth0/spring/security/api/BearerSecurityContextRepositoryTest.java
@@ -42,12 +42,37 @@ public class BearerSecurityContextRepositoryTest {
         BearerSecurityContextRepository repository = new BearerSecurityContextRepository();
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpRequestResponseHolder holder = new HttpRequestResponseHolder(request, null);
-        when(request.getHeader("Authorization")).thenReturn("Bearer ");
+        when(request.getHeader("Authorization")).thenReturn("Bearer  <Invalid>");
 
         SecurityContext context = repository.loadContext(holder);
         assertThat(context, is(notNullValue()));
         assertThat(context.getAuthentication(), is(nullValue()));
     }
+
+    @Test
+    public void shouldLoadContextWithoutAuthenticationIfEmptyAuthorizationHeaderValue() throws Exception {
+        BearerSecurityContextRepository repository = new BearerSecurityContextRepository();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpRequestResponseHolder holder = new HttpRequestResponseHolder(request, null);
+        when(request.getHeader("Authorization")).thenReturn("Bearer");
+
+        SecurityContext context = repository.loadContext(holder);
+        assertThat(context, is(notNullValue()));
+        assertThat(context.getAuthentication(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldLoadContextWithoutAuthenticationIfAuthorizationHeaderValueNotBearerToken() throws Exception {
+        BearerSecurityContextRepository repository = new BearerSecurityContextRepository();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpRequestResponseHolder holder = new HttpRequestResponseHolder(request, null);
+        when(request.getHeader("Authorization")).thenReturn("Basic somevalue");
+
+        SecurityContext context = repository.loadContext(holder);
+        assertThat(context, is(notNullValue()));
+        assertThat(context.getAuthentication(), is(nullValue()));
+    }
+
 
     @Test
     public void shouldLoadContextWithAuthentication() throws Exception {


### PR DESCRIPTION
Handle decode exception to return an empty `SecurityContext`
Spring security takes over and will return a 401 response

fixes #19 