### PR TITLE
Support additional OIDC Conformant scope claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ Temporary Items
 ## Plugin-specific files:
 
 # IntelliJ
-/out/
+**/out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/lib/src/main/java/com/auth0/spring/security/api/BearerSecurityContextRepository.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/BearerSecurityContextRepository.java
@@ -1,5 +1,6 @@
 package com.auth0.spring.security.api;
 
+import com.auth0.spring.security.api.authentication.AuthenticationJsonWebTokenFactory;
 import com.auth0.spring.security.api.authentication.PreAuthenticatedAuthenticationJsonWebToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,12 +15,19 @@ import javax.servlet.http.HttpServletResponse;
 
 public class BearerSecurityContextRepository implements SecurityContextRepository {
     private final static Logger logger = LoggerFactory.getLogger(BearerSecurityContextRepository.class);
+    private final AuthenticationJsonWebTokenFactory tokenFactory;
+    public BearerSecurityContextRepository() {
+        this(new AuthenticationJsonWebTokenFactory());
+    }
+    public BearerSecurityContextRepository(AuthenticationJsonWebTokenFactory tokenFactory) {
+        this.tokenFactory = tokenFactory;
+    }
 
     @Override
     public SecurityContext loadContext(HttpRequestResponseHolder requestResponseHolder) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         String token = tokenFromRequest(requestResponseHolder.getRequest());
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
         if (authentication != null) {
             context.setAuthentication(authentication);
             logger.debug("Found bearer token in request. Saving it in SecurityContext");

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtWebSecurityConfigurer.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtWebSecurityConfigurer.java
@@ -96,16 +96,31 @@ public class JwtWebSecurityConfigurer {
      */
     @SuppressWarnings("unused")
     public HttpSecurity configure(HttpSecurity http) throws Exception {
+        return this.configure(http, new BearerSecurityContextRepository(), new JwtAuthenticationEntryPoint());
+    }
+
+    /**
+     * Further configure the {@link HttpSecurity} object with some sensible defaults
+     * by registering objects to obtain a bearer token from a request.
+     * @param http configuration for Spring
+     * @param bearerSecurity configuration for Bearer Tokens
+     * @param http configuration for entry point
+     * @return the http configuration for further customizations
+     * @throws Exception
+     */
+    @SuppressWarnings("unused")
+    public HttpSecurity configure(HttpSecurity http, BearerSecurityContextRepository bearerSecurity, JwtAuthenticationEntryPoint entryPoint) throws Exception {
         return http
                 .authenticationProvider(provider)
                 .securityContext()
-                .securityContextRepository(new BearerSecurityContextRepository())
+                .securityContextRepository(bearerSecurity)
                 .and()
                 .exceptionHandling()
-                .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
+                .authenticationEntryPoint(entryPoint)
                 .and()
                 .httpBasic().disable()
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and();
     }
+
 }

--- a/lib/src/main/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebToken.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebToken.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public class AuthenticationJsonWebToken implements Authentication, JwtAuthentication {
+public class AuthenticationJsonWebToken implements JwtAuthentication {
 
     private final DecodedJWT decoded;
     private boolean authenticated;

--- a/lib/src/main/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebTokenFactory.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebTokenFactory.java
@@ -1,0 +1,44 @@
+package com.auth0.spring.security.api.authentication;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+
+import java.util.Collections;
+import java.util.List;
+
+public class AuthenticationJsonWebTokenFactory {
+    private static Logger logger = LoggerFactory.getLogger(AuthenticationJsonWebTokenFactory.class);
+
+    private final List<String> authorityClaims;
+    public final static String DEFAULT_SCOPE="scope";
+    public AuthenticationJsonWebTokenFactory() {
+        this(Collections.singletonList(DEFAULT_SCOPE));
+    }
+    public AuthenticationJsonWebTokenFactory(List<String> authorityClaims) {
+        this.authorityClaims = authorityClaims;
+    }
+
+    public PreAuthenticatedAuthenticationJsonWebToken usingToken(String token) {
+        if (token == null) {
+            logger.debug("No token was provided to build {}", PreAuthenticatedAuthenticationJsonWebToken.class.getName());
+            return null;
+        }
+        try {
+            DecodedJWT jwt = JWT.decode(token);
+            return new PreAuthenticatedAuthenticationJsonWebToken(jwt, this);
+        } catch (JWTDecodeException e) {
+            logger.debug("Failed to decode token as jwt", e);
+            return null;
+        }
+    }
+
+
+    public AuthenticationJsonWebToken usingTokenAndVerifier(String token, JWTVerifier verifier) {
+        return new AuthenticationJsonWebToken(token, verifier, authorityClaims, this);
+    }
+}

--- a/lib/src/main/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebTokenFactory.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebTokenFactory.java
@@ -23,7 +23,7 @@ public class AuthenticationJsonWebTokenFactory {
         this.authorityClaims = authorityClaims;
     }
 
-    public PreAuthenticatedAuthenticationJsonWebToken usingToken(String token) {
+    public JwtAuthentication usingToken(String token) {
         if (token == null) {
             logger.debug("No token was provided to build {}", PreAuthenticatedAuthenticationJsonWebToken.class.getName());
             return null;
@@ -38,7 +38,7 @@ public class AuthenticationJsonWebTokenFactory {
     }
 
 
-    public AuthenticationJsonWebToken usingTokenAndVerifier(String token, JWTVerifier verifier) {
+    public JwtAuthentication usingTokenAndVerifier(String token, JWTVerifier verifier) {
         return new AuthenticationJsonWebToken(token, verifier, authorityClaims, this);
     }
 }

--- a/lib/src/main/java/com/auth0/spring/security/api/authentication/JwtAuthentication.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/authentication/JwtAuthentication.java
@@ -4,7 +4,7 @@ import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import org.springframework.security.core.Authentication;
 
-public interface JwtAuthentication {
+public interface JwtAuthentication extends Authentication {
 
     String getToken();
 

--- a/lib/src/main/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebToken.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebToken.java
@@ -14,7 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-public class PreAuthenticatedAuthenticationJsonWebToken implements Authentication, JwtAuthentication {
+public class PreAuthenticatedAuthenticationJsonWebToken implements JwtAuthentication {
 
     private static Logger logger = LoggerFactory.getLogger(PreAuthenticatedAuthenticationJsonWebToken.class);
 

--- a/lib/src/main/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebToken.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebToken.java
@@ -12,15 +12,18 @@ import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 public class PreAuthenticatedAuthenticationJsonWebToken implements Authentication, JwtAuthentication {
 
     private static Logger logger = LoggerFactory.getLogger(PreAuthenticatedAuthenticationJsonWebToken.class);
 
     private final DecodedJWT token;
+    private final AuthenticationJsonWebTokenFactory tokenFactory;
 
-    PreAuthenticatedAuthenticationJsonWebToken(DecodedJWT token) {
+    PreAuthenticatedAuthenticationJsonWebToken(DecodedJWT token, AuthenticationJsonWebTokenFactory tokenFactory) {
         this.token = token;
+        this.tokenFactory = tokenFactory;
     }
 
     @Override
@@ -58,19 +61,6 @@ public class PreAuthenticatedAuthenticationJsonWebToken implements Authenticatio
         return token.getSubject();
     }
 
-    public static PreAuthenticatedAuthenticationJsonWebToken usingToken(String token) {
-        if (token == null) {
-            logger.debug("No token was provided to build {}", PreAuthenticatedAuthenticationJsonWebToken.class.getName());
-            return null;
-        }
-        try {
-            DecodedJWT jwt = JWT.decode(token);
-            return new PreAuthenticatedAuthenticationJsonWebToken(jwt);
-        } catch (JWTDecodeException e) {
-            logger.debug("Failed to decode token as jwt", e);
-            return null;
-        }
-    }
 
     @Override
     public String getToken() {
@@ -84,6 +74,6 @@ public class PreAuthenticatedAuthenticationJsonWebToken implements Authenticatio
 
     @Override
     public Authentication verify(JWTVerifier verifier) throws JWTVerificationException {
-        return new AuthenticationJsonWebToken(token.getToken(), verifier);
+        return tokenFactory.usingTokenAndVerifier(token.getToken(), verifier);
     }
 }

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationProviderTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationProviderTest.java
@@ -7,8 +7,10 @@ import com.auth0.jwt.exceptions.InvalidClaimException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.spring.security.api.authentication.AuthenticationJsonWebToken;
+import com.auth0.spring.security.api.authentication.AuthenticationJsonWebTokenFactory;
 import com.auth0.spring.security.api.authentication.PreAuthenticatedAuthenticationJsonWebToken;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -37,6 +39,12 @@ public class JwtAuthenticationProviderTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
+    private AuthenticationJsonWebTokenFactory tokenFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        tokenFactory = new AuthenticationJsonWebTokenFactory();
+    }
     @Test
     public void shouldCreateUsingWithSecret() throws Exception {
         JwtAuthenticationProvider provider = new JwtAuthenticationProvider("secret".getBytes(), "test-issuer", "test-audience");
@@ -76,7 +84,7 @@ public class JwtAuthenticationProviderTest {
                 .withIssuer("test-issuer")
                 .withAudience("test-audience")
                 .sign(Algorithm.HMAC256("not-real-secret"));
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -90,7 +98,7 @@ public class JwtAuthenticationProviderTest {
         String token = JWT.create()
                 .withIssuer("test-issuer")
                 .sign(Algorithm.HMAC256("secret"));
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -104,7 +112,7 @@ public class JwtAuthenticationProviderTest {
         String token = JWT.create()
                 .withAudience("test-audience")
                 .sign(Algorithm.HMAC256("secret"));
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -119,7 +127,7 @@ public class JwtAuthenticationProviderTest {
                 .withAudience("test-audience")
                 .withIssuer("some-issuer")
                 .sign(Algorithm.HMAC256("secret"));
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -134,7 +142,7 @@ public class JwtAuthenticationProviderTest {
                 .withAudience("some-audience")
                 .withIssuer("test-issuer")
                 .sign(Algorithm.HMAC256("secret"));
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -154,7 +162,7 @@ public class JwtAuthenticationProviderTest {
                 .withIssuer("test-issuer")
                 .withExpiresAt(tenSecondsAgo)
                 .sign(Algorithm.HMAC256("secret"));
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -169,7 +177,7 @@ public class JwtAuthenticationProviderTest {
                 .withAudience("test-audience")
                 .withIssuer("test-issuer")
                 .sign(Algorithm.HMAC256("secret"));
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         Authentication result = provider.authenticate(authentication);
 
@@ -191,7 +199,7 @@ public class JwtAuthenticationProviderTest {
                 .withIssuer("test-issuer")
                 .withExpiresAt(tenSecondsAgo)
                 .sign(Algorithm.HMAC256("secret"));
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         Authentication result = provider.authenticate(authentication);
         assertThat(result, is(notNullValue()));
@@ -219,7 +227,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair2.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -242,7 +250,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -265,7 +273,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -287,7 +295,7 @@ public class JwtAuthenticationProviderTest {
                 .withIssuer("test-issuer")
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("No kid found in jwt");
@@ -310,7 +318,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -334,7 +342,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -358,7 +366,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(AuthenticationServiceException.class);
         exception.expectMessage("Missing jwk provider");
@@ -380,7 +388,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(AuthenticationServiceException.class);
         exception.expectMessage("Could not retrieve jwks from issuer");
@@ -405,7 +413,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(AuthenticationServiceException.class);
         exception.expectMessage("Could not retrieve public key from issuer");
@@ -428,7 +436,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(AuthenticationServiceException.class);
         exception.expectMessage("Cannot authenticate with jwt");
@@ -457,7 +465,7 @@ public class JwtAuthenticationProviderTest {
                 .withExpiresAt(tenSecondsAgo)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         exception.expect(BadCredentialsException.class);
         exception.expectMessage("Not a valid token");
@@ -481,7 +489,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
 
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         Authentication result = provider.authenticate(authentication);
 
@@ -511,7 +519,7 @@ public class JwtAuthenticationProviderTest {
                 .withHeader(keyIdHeader)
                 .withExpiresAt(tenSecondsAgo)
                 .sign(Algorithm.RSA256(null, (RSAPrivateKey) keyPair.getPrivate()));
-        Authentication authentication = PreAuthenticatedAuthenticationJsonWebToken.usingToken(token);
+        Authentication authentication = tokenFactory.usingToken(token);
 
         Authentication result = provider.authenticate(authentication);
         assertThat(result, is(notNullValue()));

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtWebSecurityConfigurerTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtWebSecurityConfigurerTest.java
@@ -1,11 +1,15 @@
 package com.auth0.spring.security.api;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.*;
+import org.springframework.security.config.http.SessionCreationPolicy;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 public class JwtWebSecurityConfigurerTest {
 
@@ -65,4 +69,65 @@ public class JwtWebSecurityConfigurerTest {
         assertThat(configurer.provider, is(notNullValue()));
         assertThat(configurer.provider, is(provider));
     }
+
+    @Test
+    public void shouldCreateRS256ConfigurerFullyConfigured() throws Exception {
+        AuthenticationProvider provider = mock(AuthenticationProvider.class);
+        BearerSecurityContextRepository bearerSecurity = mock(BearerSecurityContextRepository.class);
+        JwtAuthenticationEntryPoint entryPoint = mock(JwtAuthenticationEntryPoint.class);
+
+        //This is a final class. Mocked using https://github.com/mockito/mockito/wiki/What's-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
+        // Due to lack of verifiability, we create multiple HttpSecurity mocks to ensure each method is invoked
+        HttpSecurity httpSecurity = mock(HttpSecurity.class);
+        HttpSecurity httpSecurityChain1 = mock(HttpSecurity.class);
+        HttpSecurity httpSecurityChain2 = mock(HttpSecurity.class);
+        HttpSecurity httpSecurityChain3 = mock(HttpSecurity.class);
+        HttpSecurity httpSecurityChain4 = mock(HttpSecurity.class);
+        HttpSecurity httpSecurityChain5 = mock(HttpSecurity.class);
+        HttpSecurity httpSecurityFinal = mock(HttpSecurity.class);
+
+        when(httpSecurity.authenticationProvider(provider)).thenReturn(httpSecurityChain1);
+        SecurityContextConfigurer<HttpSecurity> securityConfigurer = mock(SecurityContextConfigurer.class);
+        when(httpSecurityChain1.securityContext()).thenReturn(securityConfigurer);
+        when(securityConfigurer.securityContextRepository(bearerSecurity)).thenReturn(securityConfigurer);
+        when(securityConfigurer.and()).thenReturn(httpSecurityChain2);
+
+        ExceptionHandlingConfigurer<HttpSecurity> exceptionConfigurer = mock(ExceptionHandlingConfigurer.class);
+        when(httpSecurityChain2.exceptionHandling()).thenReturn(exceptionConfigurer);
+        when(exceptionConfigurer.authenticationEntryPoint(entryPoint)).thenReturn(exceptionConfigurer);
+        when(exceptionConfigurer.and()).thenReturn(httpSecurityChain3);
+
+        HttpBasicConfigurer<HttpSecurity> basicConfigurer = mock(HttpBasicConfigurer.class);
+        when (httpSecurityChain3.httpBasic()).thenReturn(basicConfigurer);
+        when(basicConfigurer.disable()).thenReturn(httpSecurityChain4);
+
+        CsrfConfigurer<HttpSecurity> csrfSecurity = mock(CsrfConfigurer.class);
+        when(httpSecurityChain4.csrf()).thenReturn(csrfSecurity);
+        when(csrfSecurity.disable()).thenReturn(httpSecurityChain5);
+
+        SessionManagementConfigurer<HttpSecurity> sessionConfigurer = mock(SessionManagementConfigurer.class);
+        when(httpSecurityChain5.sessionManagement()).thenReturn(sessionConfigurer);
+        when(sessionConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS)).thenReturn(sessionConfigurer);
+        when(sessionConfigurer.and()).thenReturn(httpSecurityFinal);
+
+
+        JwtWebSecurityConfigurer configurer = JwtWebSecurityConfigurer.forRS256("audience", "issuer", provider);
+
+        HttpSecurity configuredHttpSecurity = configurer.configure(httpSecurity, bearerSecurity, entryPoint);
+
+        // This does not test everything unfortunately but it does check that each section of configuration is called
+        assertThat(configuredHttpSecurity, Matchers.is(httpSecurityFinal));
+
+        // most things can not be verified with Mockito due to final classes being used
+//        verify(exceptionConfigurer.authenticationEntryPoint(entryPoint));
+//        verify(securityConfigurer.securityContextRepository(bearerSecurity));
+//        verify(basicConfigurer.disable());
+//        verify(csrfSecurity.disable());
+//        verify(sessionConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+
+
+
+    }
+
 }

--- a/lib/src/test/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebTokenTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebTokenTest.java
@@ -5,6 +5,7 @@ import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.spring.security.api.authentication.AuthenticationJsonWebToken;
+import com.google.common.collect.Lists;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.collection.IsEmptyCollection;
@@ -16,6 +17,7 @@ import org.springframework.security.core.GrantedAuthority;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,7 +43,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.isAuthenticated(), is(true));
     }
@@ -51,7 +53,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.isAuthenticated(), is(true));
 
@@ -65,7 +67,7 @@ public class AuthenticationJsonWebTokenTest {
                 .sign(hmacAlgorithm);
 
         JWTVerifier verifier = JWT.require(hmacAlgorithm).build();
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.isAuthenticated(), is(true));
 
@@ -81,7 +83,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withHeader(keyIdHeader)
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getKeyId(), is("key-id"));
     }
@@ -91,7 +93,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getKeyId(), is(nullValue()));
     }
@@ -102,7 +104,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getToken(), is(token));
     }
@@ -113,7 +115,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getCredentials(), is(notNullValue()));
         assertThat(auth.getCredentials(), is(instanceOf(String.class)));
@@ -126,7 +128,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getDetails(), is(notNullValue()));
         assertThat(auth.getDetails(), is(instanceOf(DecodedJWT.class)));
@@ -138,7 +140,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withSubject("1234567890")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth =tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getPrincipal(), is(notNullValue()));
         assertThat(auth.getPrincipal(), is(instanceOf(String.class)));
@@ -150,7 +152,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getPrincipal(), is(nullValue()));
     }
@@ -161,7 +163,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withSubject("1234567890")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getName(), is(notNullValue()));
         assertThat(auth.getName(), is(instanceOf(String.class)));
@@ -173,7 +175,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getName(), is(nullValue()));
     }
@@ -183,7 +185,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsEmptyCollection.empty()));
@@ -195,7 +197,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withClaim("scope", "   ")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsEmptyCollection.empty()));
@@ -207,7 +209,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withClaim("scope", "auth0 auth10")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsCollectionWithSize.hasSize(2)));
@@ -217,5 +219,69 @@ public class AuthenticationJsonWebTokenTest {
         assertThat(authorities.get(0).getAuthority(), is("auth0"));
         assertThat(authorities.get(1), is(notNullValue()));
         assertThat(authorities.get(1).getAuthority(), is("auth10"));
+    }
+    @Test
+    public void shouldIgnoreCustomClaimAsAuthoritiesByDefault() throws Exception {
+        String token = JWT.create()
+                .withArrayClaim("https://auth0.io/claims/roles", new String[]{"role1", "role2"})
+                .sign(hmacAlgorithm);
+
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token, verifier);
+        assertThat(auth, is(notNullValue()));
+        assertThat(auth.getAuthorities(), is(notNullValue()));
+        assertThat(auth.getAuthorities(), is(IsCollectionWithSize.hasSize(0)));
+    }
+
+    @Test
+    public void shouldGetCustomClaimAsAuthorities() throws Exception {
+        String[] roles = new String[] {"role1", "role2"};
+        String customClaim = "https://auth0.io/claims/roles";
+
+        String token = JWT.create()
+                .withArrayClaim(customClaim, roles)
+                .sign(hmacAlgorithm);
+
+        // make a new tokenFactory
+        tokenFactory = new AuthenticationJsonWebTokenFactory(Collections.singletonList(customClaim));
+
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
+        assertThat(auth, is(notNullValue()));
+        assertThat(auth.getAuthorities(), is(notNullValue()));
+        assertThat(auth.getAuthorities(), is(IsCollectionWithSize.hasSize(2)));
+
+
+        ArrayList<GrantedAuthority> authorities = new ArrayList<>(auth.getAuthorities());
+        assertThat(authorities.get(0), is(notNullValue()));
+        assertThat(authorities.get(0).getAuthority(), is(roles[0]));
+        assertThat(authorities.get(1), is(notNullValue()));
+        assertThat(authorities.get(1).getAuthority(), is(roles[1]));
+    }
+    @Test
+    public void shouldGetScopesAndCustomClaimAsAuthorities() throws Exception {
+        String[] roles = new String[] {"role1", "role2"};
+        String customClaim = "https://auth0.io/claims/roles";
+
+        String token = JWT.create()
+                .withArrayClaim(customClaim, roles)
+                .withClaim("scope", "auth0 auth10")
+                .sign(hmacAlgorithm);
+
+        tokenFactory = new AuthenticationJsonWebTokenFactory(Lists.newArrayList(AuthenticationJsonWebTokenFactory.DEFAULT_SCOPE, customClaim));
+
+        AuthenticationJsonWebToken auth = (AuthenticationJsonWebToken) tokenFactory.usingTokenAndVerifier(token,verifier);
+        assertThat(auth, is(notNullValue()));
+        assertThat(auth.getAuthorities(), is(notNullValue()));
+        assertThat(auth.getAuthorities(), is(IsCollectionWithSize.hasSize(4)));
+
+
+        ArrayList<GrantedAuthority> authorities = new ArrayList<>(auth.getAuthorities());
+        assertThat(authorities.get(0), is(notNullValue()));
+        assertThat(authorities.get(0).getAuthority(), is("auth0"));
+        assertThat(authorities.get(1), is(notNullValue()));
+        assertThat(authorities.get(1).getAuthority(), is("auth10"));
+        assertThat(authorities.get(2), is(notNullValue()));
+        assertThat(authorities.get(2).getAuthority(), is(roles[0]));
+        assertThat(authorities.get(3), is(notNullValue()));
+        assertThat(authorities.get(3).getAuthority(), is(roles[1]));
     }
 }

--- a/lib/src/test/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebTokenTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/authentication/AuthenticationJsonWebTokenTest.java
@@ -27,11 +27,13 @@ public class AuthenticationJsonWebTokenTest {
     public ExpectedException exception = ExpectedException.none();
     private Algorithm hmacAlgorithm;
     private JWTVerifier verifier;
+    private AuthenticationJsonWebTokenFactory tokenFactory;
 
     @Before
     public void setUp() throws Exception {
         hmacAlgorithm = Algorithm.HMAC256("secret");
         verifier = JWT.require(hmacAlgorithm).build();
+        tokenFactory = new AuthenticationJsonWebTokenFactory();
     }
 
     @Test
@@ -39,8 +41,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
-
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.isAuthenticated(), is(true));
     }
@@ -50,7 +51,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.isAuthenticated(), is(true));
 
@@ -64,7 +65,7 @@ public class AuthenticationJsonWebTokenTest {
                 .sign(hmacAlgorithm);
 
         JWTVerifier verifier = JWT.require(hmacAlgorithm).build();
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.isAuthenticated(), is(true));
 
@@ -80,7 +81,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withHeader(keyIdHeader)
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getKeyId(), is("key-id"));
     }
@@ -90,7 +91,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getKeyId(), is(nullValue()));
     }
@@ -101,7 +102,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getToken(), is(token));
     }
@@ -112,7 +113,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getCredentials(), is(notNullValue()));
         assertThat(auth.getCredentials(), is(instanceOf(String.class)));
@@ -125,7 +126,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getDetails(), is(notNullValue()));
         assertThat(auth.getDetails(), is(instanceOf(DecodedJWT.class)));
@@ -137,7 +138,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withSubject("1234567890")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth =tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getPrincipal(), is(notNullValue()));
         assertThat(auth.getPrincipal(), is(instanceOf(String.class)));
@@ -149,7 +150,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getPrincipal(), is(nullValue()));
     }
@@ -160,7 +161,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withSubject("1234567890")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getName(), is(notNullValue()));
         assertThat(auth.getName(), is(instanceOf(String.class)));
@@ -172,7 +173,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getName(), is(nullValue()));
     }
@@ -182,7 +183,7 @@ public class AuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsEmptyCollection.empty()));
@@ -194,7 +195,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withClaim("scope", "   ")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsEmptyCollection.empty()));
@@ -206,7 +207,7 @@ public class AuthenticationJsonWebTokenTest {
                 .withClaim("scope", "auth0 auth10")
                 .sign(hmacAlgorithm);
 
-        AuthenticationJsonWebToken auth = new AuthenticationJsonWebToken(token, verifier);
+        AuthenticationJsonWebToken auth = tokenFactory.usingTokenAndVerifier(token,verifier);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsCollectionWithSize.hasSize(2)));

--- a/lib/src/test/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebTokenTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebTokenTest.java
@@ -13,7 +13,6 @@ import org.junit.rules.ExpectedException;
 import java.util.Collections;
 import java.util.Map;
 
-import static com.auth0.spring.security.api.authentication.PreAuthenticatedAuthenticationJsonWebToken.usingToken;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
@@ -25,10 +24,12 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
     private Algorithm hmacAlgorithm;
+    private AuthenticationJsonWebTokenFactory tokenFactory;
 
     @Before
     public void setUp() throws Exception {
         hmacAlgorithm = Algorithm.HMAC256("secret");
+        tokenFactory = new AuthenticationJsonWebTokenFactory();
     }
 
     @Test
@@ -37,7 +38,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.isAuthenticated(), is(false));
     }
@@ -48,7 +49,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
 
         assertThat(auth.isAuthenticated(), is(false));
         auth.setAuthenticated(true);
@@ -62,7 +63,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withHeader(keyIdHeader)
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getKeyId(), is("key-id"));
     }
@@ -72,7 +73,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getKeyId(), is(nullValue()));
     }
@@ -83,7 +84,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getToken(), is(token));
     }
@@ -94,7 +95,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getCredentials(), is(notNullValue()));
         assertThat(auth.getCredentials(), is(instanceOf(String.class)));
@@ -107,7 +108,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getDetails(), is(notNullValue()));
         assertThat(auth.getDetails(), is(instanceOf(DecodedJWT.class)));
@@ -119,7 +120,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withSubject("1234567890")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getPrincipal(), is(notNullValue()));
         assertThat(auth.getPrincipal(), is(instanceOf(String.class)));
@@ -131,7 +132,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getPrincipal(), is(nullValue()));
     }
@@ -142,7 +143,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withSubject("1234567890")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getName(), is(notNullValue()));
         assertThat(auth.getName(), is(instanceOf(String.class)));
@@ -154,7 +155,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getName(), is(nullValue()));
     }
@@ -164,7 +165,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsEmptyCollection.empty()));
@@ -176,7 +177,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withClaim("scope", "read:users add:users")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsEmptyCollection.empty()));

--- a/lib/src/test/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebTokenTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebTokenTest.java
@@ -38,7 +38,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken) tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.isAuthenticated(), is(false));
     }
@@ -49,7 +49,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
 
         assertThat(auth.isAuthenticated(), is(false));
         auth.setAuthenticated(true);
@@ -63,7 +63,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withHeader(keyIdHeader)
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getKeyId(), is("key-id"));
     }
@@ -73,7 +73,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getKeyId(), is(nullValue()));
     }
@@ -84,7 +84,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getToken(), is(token));
     }
@@ -95,7 +95,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getCredentials(), is(notNullValue()));
         assertThat(auth.getCredentials(), is(instanceOf(String.class)));
@@ -108,7 +108,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withIssuer("auth0")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getDetails(), is(notNullValue()));
         assertThat(auth.getDetails(), is(instanceOf(DecodedJWT.class)));
@@ -120,7 +120,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withSubject("1234567890")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getPrincipal(), is(notNullValue()));
         assertThat(auth.getPrincipal(), is(instanceOf(String.class)));
@@ -132,7 +132,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getPrincipal(), is(nullValue()));
     }
@@ -143,7 +143,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withSubject("1234567890")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getName(), is(notNullValue()));
         assertThat(auth.getName(), is(instanceOf(String.class)));
@@ -155,7 +155,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getName(), is(nullValue()));
     }
@@ -165,7 +165,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
         String token = JWT.create()
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsEmptyCollection.empty()));
@@ -177,7 +177,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
                 .withClaim("scope", "read:users add:users")
                 .sign(hmacAlgorithm);
 
-        PreAuthenticatedAuthenticationJsonWebToken auth = tokenFactory.usingToken(token);
+        PreAuthenticatedAuthenticationJsonWebToken auth = (PreAuthenticatedAuthenticationJsonWebToken)tokenFactory.usingToken(token);
         assertThat(auth, is(notNullValue()));
         assertThat(auth.getAuthorities(), is(notNullValue()));
         assertThat(auth.getAuthorities(), is(IsEmptyCollection.empty()));

--- a/lib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/lib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Fixes #11 

Will discuss changes in the diff.

Here is example code to use it in Kotlin. This also uses @ConfigurationProperties 
```
import com.auth0.spring.security.api.BearerSecurityContextRepository
import com.auth0.spring.security.api.JwtAuthenticationEntryPoint
import com.auth0.spring.security.api.JwtWebSecurityConfigurer
import com.auth0.spring.security.api.authentication.AuthenticationJsonWebTokenFactory
import org.slf4j.Logger
import org.slf4j.LoggerFactory
import org.springframework.boot.context.properties.ConfigurationProperties
import org.springframework.context.annotation.Configuration
import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
import org.springframework.security.config.annotation.web.builders.HttpSecurity
import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter

@Configuration
@EnableWebSecurity
@EnableGlobalMethodSecurity(prePostEnabled = true)
class SecurityConfig( val config: Auth0Config) : WebSecurityConfigurerAdapter() {
    val log: Logger = LoggerFactory.getLogger(this.javaClass)

    @Configuration
    @ConfigurationProperties("auth0")
    class Auth0Config {
        lateinit var apiAudience: String
        lateinit var issuer: String
        var authorityClaims = listOf(AuthenticationJsonWebTokenFactory.DEFAULT_SCOPE);
    }

    @Throws(Exception::class)
    override fun configure(http: HttpSecurity) {
        val bearerSecurity = BearerSecurityContextRepository(AuthenticationJsonWebTokenFactory(config.authorityClaims))
        val entryPoint = JwtAuthenticationEntryPoint()
        log.info("Initializing JWT for apiAudience {}, issuer {}, claims {}", config.apiAudience, config.issuer, config.authorityClaims)
        JwtWebSecurityConfigurer.forRS256(config.apiAudience, config.issuer)
                .configure(http, bearerSecurity, entryPoint)
                .cors().and().csrf().disable().authorizeRequests()
                .antMatchers("/channels/**").hasAuthority("youtube-read")
                .antMatchers("/admin/**").hasAuthority("youtube-admin")

                .anyRequest().permitAll()
    }

}
```

This change is backwards compatible.