### PR TITLE
Bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.8.0'
+        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.9.0'
     }
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -31,14 +31,14 @@ compileJava {
 }
 
 dependencies {
-    implementation 'com.auth0:java-jwt:3.5.0'
-    implementation 'com.auth0:jwks-rsa:0.7.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-    implementation 'commons-codec:commons-codec:1.11'
-    implementation 'org.springframework.security:spring-security-core:4.2.9.RELEASE'
-    implementation 'org.springframework.security:spring-security-web:4.2.9.RELEASE'
-    implementation 'org.springframework.security:spring-security-config:4.2.9.RELEASE'
-    implementation 'org.slf4j:slf4j-api:1.7.25'
+    implementation 'com.auth0:java-jwt:3.8.+'
+    implementation 'com.auth0:jwks-rsa:0.8.+'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
+    implementation 'commons-codec:commons-codec:1.12'
+    implementation 'org.springframework.security:spring-security-core:4.2.12.RELEASE'
+    implementation 'org.springframework.security:spring-security-web:4.2.12.RELEASE'
+    implementation 'org.springframework.security:spring-security-config:4.2.12.RELEASE'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
     compileOnly 'javax.servlet:servlet-api:2.5'
 
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
### Changes

- Bump dependencies to latest, fixing jackson-databind vulnarability
- use dynamic patch versions for auth0 libs
- Use latest auth0 oss plugin version

