### PR TITLE
Deal with list of issuers in JwtAuthenticationProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 > If you need further customization (like a leeway for JWT verification) use the `JwtWebSecurityConfigurer` signatures which accept a `JwtAuthenticationProvider`.
 
+> If you need to configure several allowed issuers use the `JwtWebSecurityConfigurer` signatures which accept a `String[] issuers`.
+
 
 Then using Spring Security `HttpSecurity` you can specify which paths requires authentication
 

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtWebSecurityConfigurer.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtWebSecurityConfigurer.java
@@ -13,12 +13,12 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 public class JwtWebSecurityConfigurer {
 
     final String audience;
-    final String issuer;
+    final String[] issuers;
     final AuthenticationProvider provider;
 
-    private JwtWebSecurityConfigurer(String audience, String issuer, AuthenticationProvider authenticationProvider) {
+    private JwtWebSecurityConfigurer(String audience, String[] issuers, AuthenticationProvider authenticationProvider) {
         this.audience = audience;
-        this.issuer = issuer;
+        this.issuers = issuers;
         this.provider = authenticationProvider;
     }
 
@@ -32,8 +32,7 @@ public class JwtWebSecurityConfigurer {
      */
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
     public static JwtWebSecurityConfigurer forRS256(String audience, String issuer) {
-        final JwkProvider jwkProvider = new JwkProviderBuilder(issuer).build();
-        return new JwtWebSecurityConfigurer(audience, issuer, new JwtAuthenticationProvider(jwkProvider, issuer, audience));
+        return forRS256(audience, new String[]{issuer});
     }
 
     /**
@@ -47,7 +46,35 @@ public class JwtWebSecurityConfigurer {
      */
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
     public static JwtWebSecurityConfigurer forRS256(String audience, String issuer, AuthenticationProvider provider) {
-        return new JwtWebSecurityConfigurer(audience, issuer, provider);
+        return forRS256(audience, new String[]{issuer}, provider);
+    }
+
+    /**
+     * Configures application authorization for JWT signed with RS256.
+     * Will try to validate the token using the public key downloaded from "$issuer/.well-known/jwks.json"
+     * and matched by the value of {@code kid} of the JWT header
+     * @param audience identifier of the API and must match the {@code aud} value in the token
+     * @param issuers array of allowed issuers of the token for this API and one of the entries must match the {@code iss} value in the token
+     * @return JwtWebSecurityConfigurer for further configuration
+     */
+    @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
+    public static JwtWebSecurityConfigurer forRS256(String audience, String[] issuers) {
+        final JwkProvider jwkProvider = new JwkProviderBuilder(issuers[0]).build(); // we use the first issuer for getting the jwkProvider
+        return new JwtWebSecurityConfigurer(audience, issuers, new JwtAuthenticationProvider(jwkProvider, issuers, audience));
+    }
+
+    /**
+     * Configures application authorization for JWT signed with RS256
+     * Will try to validate the token using the public key downloaded from "$issuer/.well-known/jwks.json"
+     * and matched by the value of {@code kid} of the JWT header
+     * @param audience identifier of the API and must match the {@code aud} value in the token
+     * @param issuers array of allowed issuers of the token for this API and one of the entries must match the {@code iss} value in the token
+     * @param provider of Spring Authentication objects that can validate a {@link com.auth0.spring.security.api.authentication.PreAuthenticatedAuthenticationJsonWebToken}
+     * @return JwtWebSecurityConfigurer for further configuration
+     */
+    @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
+    public static JwtWebSecurityConfigurer forRS256(String audience, String[] issuers, AuthenticationProvider provider) {
+        return new JwtWebSecurityConfigurer(audience, issuers, provider);
     }
 
     /**
@@ -59,8 +86,7 @@ public class JwtWebSecurityConfigurer {
      */
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
     public static JwtWebSecurityConfigurer forHS256WithBase64Secret(String audience, String issuer, String secret) {
-        final byte[] secretBytes = new Base64(true).decode(secret);
-        return new JwtWebSecurityConfigurer(audience, issuer, new JwtAuthenticationProvider(secretBytes, issuer, audience));
+        return forHS256WithBase64Secret(audience, new String[]{issuer}, secret);
     }
 
     /**
@@ -72,7 +98,7 @@ public class JwtWebSecurityConfigurer {
      */
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
     public static JwtWebSecurityConfigurer forHS256(String audience, String issuer, byte[] secret) {
-        return new JwtWebSecurityConfigurer(audience, issuer, new JwtAuthenticationProvider(secret, issuer, audience));
+        return forHS256(audience, new String[]{issuer}, secret);
     }
 
     /**
@@ -84,7 +110,44 @@ public class JwtWebSecurityConfigurer {
      */
     @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
     public static JwtWebSecurityConfigurer forHS256(String audience, String issuer, AuthenticationProvider provider) {
-        return new JwtWebSecurityConfigurer(audience, issuer, provider);
+        return forHS256(audience, new String[]{issuer}, provider);
+    }
+
+    /**
+     * Configures application authorization for JWT signed with HS256
+     * @param audience identifier of the API and must match the {@code aud} value in the token
+     * @param issuers array of allowed issuers of the token for this API and one of the entries must match the {@code iss} value in the token
+     * @param secret used to sign and verify tokens encoded in Base64
+     * @return JwtWebSecurityConfigurer for further configuration
+     */
+    @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
+    public static JwtWebSecurityConfigurer forHS256WithBase64Secret(String audience, String[] issuers, String secret) {
+        final byte[] secretBytes = new Base64(true).decode(secret);
+        return new JwtWebSecurityConfigurer(audience, issuers, new JwtAuthenticationProvider(secretBytes, issuers, audience));
+    }
+
+    /**
+     * Configures application authorization for JWT signed with HS256
+     * @param audience identifier of the API and must match the {@code aud} value in the token
+     * @param issuers array of allowed issuers of the token for this API and one of the entries must match the {@code iss} value in the token
+     * @param secret used to sign and verify tokens
+     * @return JwtWebSecurityConfigurer for further configuration
+     */
+    @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
+    public static JwtWebSecurityConfigurer forHS256(String audience, String[] issuers, byte[] secret) {
+        return new JwtWebSecurityConfigurer(audience, issuers, new JwtAuthenticationProvider(secret, issuers, audience));
+    }
+
+    /**
+     * Configures application authorization for JWT signed with HS256
+     * @param audience identifier of the API and must match the {@code aud} value in the token
+     * @param issuers list of allowed issuers of the token for this API and one of the entries must match the {@code iss} value in the token
+     * @param provider of Spring Authentication objects that can validate a {@link com.auth0.spring.security.api.authentication.PreAuthenticatedAuthenticationJsonWebToken}
+     * @return JwtWebSecurityConfigurer for further configuration
+     */
+    @SuppressWarnings({"WeakerAccess", "SameParameterValue"})
+    public static JwtWebSecurityConfigurer forHS256(String audience, String[] issuers, AuthenticationProvider provider) {
+        return new JwtWebSecurityConfigurer(audience, issuers, provider);
     }
 
     /**

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtWebSecurityConfigurerTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtWebSecurityConfigurerTest.java
@@ -15,7 +15,8 @@ public class JwtWebSecurityConfigurerTest {
 
         assertThat(configurer, is(notNullValue()));
         assertThat(configurer.audience, is("audience"));
-        assertThat(configurer.issuer, is("issuer"));
+        assertThat(configurer.issuers, arrayWithSize(1));
+        assertThat(configurer.issuers, arrayContaining("issuer"));
         assertThat(configurer.provider, is(notNullValue()));
         assertThat(configurer.provider, is(instanceOf(JwtAuthenticationProvider.class)));
     }
@@ -27,7 +28,8 @@ public class JwtWebSecurityConfigurerTest {
 
         assertThat(configurer, is(notNullValue()));
         assertThat(configurer.audience, is("audience"));
-        assertThat(configurer.issuer, is("issuer"));
+        assertThat(configurer.issuers, arrayWithSize(1));
+        assertThat(configurer.issuers, arrayContaining("issuer"));
         assertThat(configurer.provider, is(notNullValue()));
         assertThat(configurer.provider, is(provider));
     }
@@ -38,7 +40,8 @@ public class JwtWebSecurityConfigurerTest {
 
         assertThat(configurer, is(notNullValue()));
         assertThat(configurer.audience, is("audience"));
-        assertThat(configurer.issuer, is("issuer"));
+        assertThat(configurer.issuers, arrayWithSize(1));
+        assertThat(configurer.issuers, arrayContaining("issuer"));
         assertThat(configurer.provider, is(notNullValue()));
         assertThat(configurer.provider, is(instanceOf(JwtAuthenticationProvider.class)));
     }
@@ -49,7 +52,20 @@ public class JwtWebSecurityConfigurerTest {
 
         assertThat(configurer, is(notNullValue()));
         assertThat(configurer.audience, is("audience"));
-        assertThat(configurer.issuer, is("issuer"));
+        assertThat(configurer.issuers, arrayWithSize(1));
+        assertThat(configurer.issuers, arrayContaining("issuer"));
+        assertThat(configurer.provider, is(notNullValue()));
+        assertThat(configurer.provider, is(instanceOf(JwtAuthenticationProvider.class)));
+    }
+
+    @Test
+    public void shouldCreateHS256ConfigurerWithSeveralIssuers() throws Exception {
+        JwtWebSecurityConfigurer configurer = JwtWebSecurityConfigurer.forHS256("audience", new String[]{"issuer1", "issuer2"}, "secret".getBytes());
+
+        assertThat(configurer, is(notNullValue()));
+        assertThat(configurer.audience, is("audience"));
+        assertThat(configurer.issuers, arrayWithSize(2));
+        assertThat(configurer.issuers, arrayContaining("issuer1", "issuer2"));
         assertThat(configurer.provider, is(notNullValue()));
         assertThat(configurer.provider, is(instanceOf(JwtAuthenticationProvider.class)));
     }
@@ -61,7 +77,8 @@ public class JwtWebSecurityConfigurerTest {
 
         assertThat(configurer, is(notNullValue()));
         assertThat(configurer.audience, is("audience"));
-        assertThat(configurer.issuer, is("issuer"));
+        assertThat(configurer.issuers, arrayWithSize(1));
+        assertThat(configurer.issuers, arrayContaining("issuer"));
         assertThat(configurer.provider, is(notNullValue()));
         assertThat(configurer.provider, is(provider));
     }


### PR DESCRIPTION
### Changes

When we wanted to switch to a custom domain, we had the requirement that the original auth0 subdomain still works for legacy applications.
Thus, I refactored this Spring Security integration, so that it can deal with several issuers.
Since https://github.com/auth0/java-jwt/pull/288 is merged in Java JWT, it is straightforward to do this.
One holding limitation is that all issuers need to have the same public key in case of RS256 and the same secret in case of HS256. Nevertheless, this is the case for Auth0 custom domains of the same tenant.
I want to stress here, that multiple tenants are not supported. We only cover the case of several issuers domains of one Auth0 tenant.

I decided to leave as much of the existing code as possible in order to guarantee backward compatibility.
The respective functions can now be called with a list of issuers or, as before, with one issuer.
I added tests to cover the cases of several issuers.

### Testing

I tested the change with our API and several issuers.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ X ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ X ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ X ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ X ] All existing and new tests complete without errors
