### PR TITLE
Bump dependency versions

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -33,17 +33,17 @@ compileJava {
 dependencies {
     implementation 'com.auth0:java-jwt:3.8.1'
     implementation 'com.auth0:jwks-rsa:0.8.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9.1'
     implementation 'commons-codec:commons-codec:1.12'
-    implementation 'org.springframework.security:spring-security-core:4.2.12.RELEASE'
-    implementation 'org.springframework.security:spring-security-web:4.2.12.RELEASE'
-    implementation 'org.springframework.security:spring-security-config:4.2.12.RELEASE'
+    implementation 'org.springframework.security:spring-security-core:4.2.13.RELEASE'
+    implementation 'org.springframework.security:spring-security-web:4.2.13.RELEASE'
+    implementation 'org.springframework.security:spring-security-config:4.2.13.RELEASE'
     implementation 'org.slf4j:slf4j-api:1.7.26'
     compileOnly 'javax.servlet:servlet-api:2.5'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.mockito:mockito-core:2.28.2'
     testCompile 'javax.servlet:servlet-api:2.5'
 }
 


### PR DESCRIPTION
### Changes

Update dependencies to address reported security vulnerabilities in `jackson-databind` and `spring-security-core`

### References

https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207
https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-450242