### PR TITLE
Update jackson-databind to address CVE-2019-14379 and CVE-2019-14439

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -31,9 +31,9 @@ compileJava {
 }
 
 dependencies {
-    implementation 'com.auth0:java-jwt:3.8.1'
-    implementation 'com.auth0:jwks-rsa:0.8.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9.1'
+    implementation 'com.auth0:java-jwt:3.8.2'
+    implementation 'com.auth0:jwks-rsa:0.8.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9.3'
     implementation 'commons-codec:commons-codec:1.12'
     implementation 'org.springframework.security:spring-security-core:4.2.13.RELEASE'
     implementation 'org.springframework.security:spring-security-web:4.2.13.RELEASE'


### PR DESCRIPTION
### Changes

- Update to `jackson-databind` version `2.9.9.3` to address security vulnerabilities
- Update Auth0 dependencies to latest

### References

- https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-455617

### Testing

`./gradlew clean check` passing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
