### PR TITLE
Expose public API dependencies as api scope and update versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Spring Security integration with Auth0 to secure your API with Json Web Tokens (JWT)
 
-> If you need to check the old version please check the branch [v0](https://github.com/auth0/auth0-spring-security-api/tree/v0)
+> This library targets Spring 4 and Spring Boot 1. If you are using Spring 5 and Spring Boot 2, please see the [Spring Security 5 API Quickstart](https://auth0.com/docs/quickstart/backend/java-spring-security5).
 
 ## Download
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -30,21 +30,23 @@ compileJava {
     targetCompatibility '1.7'
 }
 
-dependencies {
-    implementation 'com.auth0:java-jwt:3.8.3'
-    implementation 'com.auth0:jwks-rsa:0.9.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0.pr3'
-    implementation 'commons-codec:commons-codec:1.12'
-    implementation 'org.springframework.security:spring-security-core:4.2.13.RELEASE'
-    implementation 'org.springframework.security:spring-security-web:4.2.13.RELEASE'
-    implementation 'org.springframework.security:spring-security-config:4.2.13.RELEASE'
-    implementation 'org.slf4j:slf4j-api:1.7.26'
-    compileOnly 'javax.servlet:servlet-api:2.5'
+ext.springSecurityVersion = '4.2.15.RELEASE'
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
-    testCompile 'javax.servlet:servlet-api:2.5'
+dependencies {
+    api "com.auth0:java-jwt:3.10.2"
+    api "com.auth0:jwks-rsa:0.11.0"
+    api "org.springframework.security:spring-security-core:${springSecurityVersion}"
+    api "org.springframework.security:spring-security-web:${springSecurityVersion}"
+    api "org.springframework.security:spring-security-config:${springSecurityVersion}"
+
+    implementation "commons-codec:commons-codec:1.14"
+    implementation "org.slf4j:slf4j-api:1.7.30"
+    compileOnly "javax.servlet:servlet-api:2.5"
+
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.hamcrest:java-hamcrest:2.0.0.0"
+    testImplementation "org.mockito:mockito-core:2.28.2"
+    testCompile "javax.servlet:servlet-api:2.5"
 }
 
 jacocoTestReport {


### PR DESCRIPTION
### Changes

Makes the following dependencies available to use through transitive dependencies, which are used by the public API of this library:
- `com.auth0:java-jwt`
- `com.auth0:jwks-rsa`
- `org.springframework.security:spring-security-core`
- `org.springframework.security:spring-security-web`
- `org.springframework.security:spring-security-config`

Also makes the following changes:
- Updates the dependency versions to the latest minor/patch releases available.
- Clarifies the targeted Spring versions for this library

Fixes #44 and #43 

### References

[Gradle dependency scopes](https://docs.gradle.org/current/userguide/dependency_management_for_java_projects.html#sec:module_dependencies_java_tutorial)

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
