### PR TITLE
Add WWW-Authenticate header.

### DIFF
--- a/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,6 @@
 package com.auth0.spring.security.api;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -20,9 +21,11 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        String modifiedIssuer = this.issuer.endsWith("/") ? this.issuer.substring(0, this.issuer.length() - 1) : this.issuer;
+
         response.addHeader(
-                "WWW-Authenticate",
-                String.format("Bearer realm=\"%s\", authorization_uri=\"%soauth/token\"", this.audience, this.issuer)
+                HttpHeaders.WWW_AUTHENTICATE,
+                String.format("Bearer realm=\"%s\", authorization_uri=\"%s/authorize\"", this.audience, modifiedIssuer)
         );
 
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
@@ -9,8 +9,22 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    final String audience;
+    final String issuer;
+
+    public JwtAuthenticationEntryPoint(String audience, String issuer) {
+        this.audience = audience;
+        this.issuer = issuer;
+    }
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setHeader(
+                "WWW-Authenticate",
+                String.format("Bearer realm=\"%s\", authorization_uri=\"%soauth/token", this.audience, this.issuer)
+        );
+
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
     }
 }

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
@@ -20,9 +20,9 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.setHeader(
+        response.addHeader(
                 "WWW-Authenticate",
-                String.format("Bearer realm=\"%s\", authorization_uri=\"%soauth/token", this.audience, this.issuer)
+                String.format("Bearer realm=\"%s\", authorization_uri=\"%soauth/token\"", this.audience, this.issuer)
         );
 
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtWebSecurityConfigurer.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtWebSecurityConfigurer.java
@@ -102,7 +102,7 @@ public class JwtWebSecurityConfigurer {
                 .securityContextRepository(new BearerSecurityContextRepository())
                 .and()
                 .exceptionHandling()
-                .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
+                .authenticationEntryPoint(new JwtAuthenticationEntryPoint(audience, issuer))
                 .and()
                 .httpBasic().disable()
                 .csrf().disable()

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationEntryPointTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationEntryPointTest.java
@@ -6,19 +6,22 @@ import org.springframework.security.core.AuthenticationException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class JwtAuthenticationEntryPointTest {
 
     @Test
     public void shouldReturnUnauthorized() throws Exception {
-        JwtAuthenticationEntryPoint entryPoint = new JwtAuthenticationEntryPoint();
+        JwtAuthenticationEntryPoint entryPoint = new JwtAuthenticationEntryPoint("https://api.example.org/", "https://example.auth0.com/");
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
         AuthenticationException exception = mock(AuthenticationException.class);
 
         entryPoint.commence(request, response, exception);
+        verify(response).addHeader(
+                "WWW-Authenticate",
+                "Bearer realm=\"https://api.example.org/\", authorization_uri=\"https://example.auth0.com/oauth/token\""
+        );
         verify(response).sendError(401, "Unauthorized");
     }
 

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationEntryPointTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationEntryPointTest.java
@@ -1,6 +1,7 @@
 package com.auth0.spring.security.api;
 
 import org.junit.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.AuthenticationException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -19,10 +20,24 @@ public class JwtAuthenticationEntryPointTest {
 
         entryPoint.commence(request, response, exception);
         verify(response).addHeader(
-                "WWW-Authenticate",
-                "Bearer realm=\"https://api.example.org/\", authorization_uri=\"https://example.auth0.com/oauth/token\""
+                HttpHeaders.WWW_AUTHENTICATE,
+                "Bearer realm=\"https://api.example.org/\", authorization_uri=\"https://example.auth0.com/authorize\""
         );
         verify(response).sendError(401, "Unauthorized");
     }
 
+    @Test
+    public void shouldReturnUnauthorized_2() throws Exception {
+        JwtAuthenticationEntryPoint entryPoint = new JwtAuthenticationEntryPoint("https://api.example.org/", "https://example.auth0.com");
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        AuthenticationException exception = mock(AuthenticationException.class);
+
+        entryPoint.commence(request, response, exception);
+        verify(response).addHeader(
+                HttpHeaders.WWW_AUTHENTICATE,
+                "Bearer realm=\"https://api.example.org/\", authorization_uri=\"https://example.auth0.com/authorize\""
+        );
+        verify(response).sendError(401, "Unauthorized");
+    }
 }


### PR DESCRIPTION
This change adds the WWW-Authenticate header in case of a 401 response, as the JWT standard requires it.