### PR TITLE
Add WWW-Authenticate header for 401 and 403 requests

### DIFF
--- a/lib/src/main/java/com/auth0/spring/security/api/JwtAccessDeniedHandler.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.auth0.spring.security.api;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandlerImpl;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Custom handler for access denied exceptions.
+ */
+class JwtAccessDeniedHandler extends AccessDeniedHandlerImpl {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.addHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer error=\"Insufficient scope\"");
+        super.handle(request, response, accessDeniedException);
+    }
+}

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,6 @@
 package com.auth0.spring.security.api;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -9,8 +10,14 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.addHeader(
+                HttpHeaders.WWW_AUTHENTICATE,
+                "Bearer error=\"Invalid access token\""
+        );
+
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
     }
 }

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtWebSecurityConfigurer.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtWebSecurityConfigurer.java
@@ -103,6 +103,7 @@ public class JwtWebSecurityConfigurer {
                 .and()
                 .exceptionHandling()
                 .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
+                .accessDeniedHandler(new JwtAccessDeniedHandler())
                 .and()
                 .httpBasic().disable()
                 .csrf().disable()

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtAccessDeniedHandlerTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtAccessDeniedHandlerTest.java
@@ -1,0 +1,28 @@
+package com.auth0.spring.security.api;
+
+import org.junit.Test;
+import org.springframework.security.access.AccessDeniedException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class JwtAccessDeniedHandlerTest {
+
+    @Test
+    public void shouldReturnForbidden() throws Exception {
+        JwtAccessDeniedHandler handler = new JwtAccessDeniedHandler();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        AccessDeniedException exception = new AccessDeniedException("Forbidden");// mock(AccessDeniedException.class);
+
+        handler.handle(request, response, exception);
+        verify(response).addHeader(
+                "WWW-Authenticate",
+                "Bearer error=\"Insufficient scope\""
+        );
+        verify(response).sendError(403, "Forbidden");
+    }
+}

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtAccessDeniedHandlerTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtAccessDeniedHandlerTest.java
@@ -16,7 +16,7 @@ public class JwtAccessDeniedHandlerTest {
         JwtAccessDeniedHandler handler = new JwtAccessDeniedHandler();
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
-        AccessDeniedException exception = new AccessDeniedException("Forbidden");// mock(AccessDeniedException.class);
+        AccessDeniedException exception = new AccessDeniedException("Forbidden");
 
         handler.handle(request, response, exception);
         verify(response).addHeader(

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationEntryPointTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationEntryPointTest.java
@@ -19,7 +19,10 @@ public class JwtAuthenticationEntryPointTest {
         AuthenticationException exception = mock(AuthenticationException.class);
 
         entryPoint.commence(request, response, exception);
+        verify(response).addHeader(
+                "WWW-Authenticate",
+                "Bearer error=\"Invalid access token\""
+        );
         verify(response).sendError(401, "Unauthorized");
     }
-
 }


### PR DESCRIPTION
### Changes

As raised in #47, the `WWW-Authenticate` headers should be sent on the response when the request is rejected due to a missing or invalid access token. This is specified by [RFC 6750](https://tools.ietf.org/html/rfc6750#section-3).

#### Scenarios

- Requests to a resource that require authorization that are rejected with a `401` due to an invalid or missing access token will have a `WWW-Authenticate` header included on the response.
- Requests to a resource that are rejected with a `403` due to insufficient scopes will have a `WWW-Authenticate` header included on the response.  

#### WWW-Authenticate header value

[RFC 6750](https://tools.ietf.org/html/rfc6750#section-3) does not require any specific attributes of the `WWW-Authenticate` header to be set. This PR simply includes an `error` attribute, with the following values:

- "Invalid token" for a `401` resulting from a missing or invalid access token
- "Insufficient scope" for a `403` resulting from a token with insufficient scopes

A couple notes on what could be added in the future, but is not included here as this change is focused on complying with RFC 6750 and enables future changes to the header attributes:

- In the case of `401` errors, we could unwrap the `AuthenticationException` and use the underlying exception cause to return a more specific `error` (e.g., invalid signature, expired token, etc).
- In the case of `403` errors, we _might_ be able to included the required scopes for the resource, as [was added to express-jwt-authz](https://github.com/auth0/express-jwt-authz/pull/20). That would require some more thought, since we'd need to be able to hook into the required scopes as configured by the application developer.
- We could include attributes such as the `realm` or `authorization_uri`, if those prove to be useful for callers.

Again, those possible additions are not included in this PR for the purposes of simplicity and compliance, but we can consider them going forward.

### References

- [RFC 6750](https://tools.ietf.org/html/rfc6750#section-3)
- #50 
- #47 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [X] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
