### PR TITLE
Update java jwt and jwks

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,7 +34,7 @@ ext.springSecurityVersion = '4.2.20.RELEASE'
 
 dependencies {
     api "com.auth0:java-jwt:3.18.3"
-    api "com.auth0:jwks-rsa:0.15.0"
+    api "com.auth0:jwks-rsa:0.20.1"
     api "org.springframework.security:spring-security-core:${springSecurityVersion}"
     api "org.springframework.security:spring-security-web:${springSecurityVersion}"
     api "org.springframework.security:spring-security-config:${springSecurityVersion}"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -33,7 +33,7 @@ compileJava {
 ext.springSecurityVersion = '4.2.20.RELEASE'
 
 dependencies {
-    api "com.auth0:java-jwt:3.13.0"
+    api "com.auth0:java-jwt:3.18.3"
     api "com.auth0:jwks-rsa:0.15.0"
     api "org.springframework.security:spring-security-core:${springSecurityVersion}"
     api "org.springframework.security:spring-security-web:${springSecurityVersion}"


### PR DESCRIPTION
### Changes

We are upgrading [java-jwt](https://github.com/auth0/java-jwt) and [jwks-rsa-java](https://github.com/auth0/jwks-rsa-java) library dependency to 3.18.3 and 0.20.1 respectively. This is because of their transitive dependency on the vulnerable version of Jackson

### References
[Link](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698)

### Testing
Since this is a dependency upgrade, we checked it using our existing unit tests