### PR TITLE
Update auth0 dependencies to address CVE-2020-36518

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -33,8 +33,8 @@ compileJava {
 ext.springSecurityVersion = '4.2.20.RELEASE'
 
 dependencies {
-    api "com.auth0:java-jwt:3.18.3"
-    api "com.auth0:jwks-rsa:0.20.1"
+    api "com.auth0:java-jwt:3.19.0"
+    api "com.auth0:jwks-rsa:0.21.0"
     api "org.springframework.security:spring-security-core:${springSecurityVersion}"
     api "org.springframework.security:spring-security-web:${springSecurityVersion}"
     api "org.springframework.security:spring-security-config:${springSecurityVersion}"


### PR DESCRIPTION
### Changes

This PR bumps the `com.auth0` dependencies to latest versions. This addresses [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) for the transient `jackson-databind` dependency.

### References
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518