### PR TITLE
Bump transitive jackson dependencies in auth0 libraries

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -33,8 +33,8 @@ compileJava {
 ext.springSecurityVersion = '4.2.20.RELEASE'
 
 dependencies {
-    api "com.auth0:java-jwt:3.19.0"
-    api "com.auth0:jwks-rsa:0.21.0"
+    api "com.auth0:java-jwt:3.19.1"
+    api "com.auth0:jwks-rsa:0.21.1"
     api "org.springframework.security:spring-security-core:${springSecurityVersion}"
     api "org.springframework.security:spring-security-web:${springSecurityVersion}"
     api "org.springframework.security:spring-security-config:${springSecurityVersion}"


### PR DESCRIPTION
This PR bumps the auth0 libraries using jackson-databind dependency to 2.13.2.2 to address [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) in that library