### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.5.1](https://github.com/auth0/auth0-spring-security-api/tree/1.5.1) (2022-03-30)
+[Full Changelog](https://github.com/auth0/auth0-spring-security-api/compare/1.5.0...1.5.1)
+
+**Security**
+- Bump transitive jackson dependencies in auth0 libraries [\#68](https://github.com/auth0/auth0-spring-security-api/pull/68) ([poovamraj](https://github.com/poovamraj))
+
 ## [1.5.0](https://github.com/auth0/auth0-spring-security-api/tree/1.5.0) (2022-03-14)
 [Full Changelog](https://github.com/auth0/auth0-spring-security-api/compare/1.4.1...1.5.0)
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Get Auth0 Spring Security API using Maven:
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>auth0-spring-security-api</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:auth0-spring-security-api:1.5.0'
+implementation 'com.auth0:auth0-spring-security-api:1.5.1'
 ```
 
 ## Usage


### PR DESCRIPTION
## [1.5.1](https://github.com/auth0/auth0-spring-security-api/tree/1.5.1) (2022-03-30)
[Full Changelog](https://github.com/auth0/auth0-spring-security-api/compare/1.5.0...1.5.1)

**Security**
- Bump transitive jackson dependencies in auth0 libraries [\#68](https://github.com/auth0/auth0-spring-security-api/pull/68) ([poovamraj](https://github.com/poovamraj))