### PR TITLE
Upgrade to Spring Security 6, requiring Java 17 and Gradle 7.3 minimum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,28 +7,26 @@ orbs:
 jobs:
   build:
     docker:
-      - image: openjdk:8-jdk
+      - image: cimg/openjdk:17.0
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
       _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
       TERM: dumb
     steps:
       - checkout
-      
-      - run: chmod +x gradlew
-      
+
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "lib/build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-          
+            - v1-dependencies-{{ checksum "lib/build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
       # run tests!
       - run: ./gradlew clean check jacocoTestReport --continue --console=plain
-      
+
       - codecov/upload
-      
+
       - save_cache:
           paths:
             - ~/.m2

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,13 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        jcenter()
     }
-    dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'com.auth0.gradle:oss-library:0.17.2'
-    }
+}
+
+plugins {
+    id "com.auth0.gradle.oss-library.java" version "0.18.0"
+    id "com.jfrog.bintray" version "1.+"
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,5 +1,9 @@
 buildscript {
-    version = "1.5.2"
+    version = "2.0.0"
+}
+
+plugins {
+    id "io.spring.dependency-management" version "1.1.0"
 }
 
 apply plugin: 'idea'
@@ -11,6 +15,12 @@ def signingKeyPwd = findProperty('signingPassword')
 
 signing {
     useInMemoryPgpKeys(signingKey, signingKeyPwd)
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.security:spring-security-bom:6.0.0"
+    }
 }
 
 oss {
@@ -38,27 +48,29 @@ oss {
 logger.lifecycle("Using version ${version} for ${group}.${name}")
 
 compileJava {
-    sourceCompatibility '1.7'
-    targetCompatibility '1.7'
+    sourceCompatibility '17'
+    targetCompatibility '17'
+}
+compileTestJava {
+    sourceCompatibility '17'
+    targetCompatibility '17'
 }
 
-ext.springSecurityVersion = '4.2.20.RELEASE'
-
 dependencies {
-    api "com.auth0:java-jwt:3.19.3"
+    api "com.auth0:java-jwt:4.2.1"
     api "com.auth0:jwks-rsa:0.21.2"
-    api "org.springframework.security:spring-security-core:${springSecurityVersion}"
-    api "org.springframework.security:spring-security-web:${springSecurityVersion}"
-    api "org.springframework.security:spring-security-config:${springSecurityVersion}"
+    api "org.springframework.security:spring-security-core"
+    api "org.springframework.security:spring-security-web"
+    api "org.springframework.security:spring-security-config"
 
     implementation "commons-codec:commons-codec:1.15"
-    implementation "org.slf4j:slf4j-api:1.7.36"
-    compileOnly "javax.servlet:servlet-api:2.5"
+    implementation "org.slf4j:slf4j-api:2.0.5"
+    compileOnly "jakarta.servlet:jakarta.servlet-api:6.0.0"
 
-    testImplementation "junit:junit:4.12"
-    testImplementation "org.hamcrest:java-hamcrest:2.0.0.0"
-    testImplementation "org.mockito:mockito-core:2.28.2"
-    testCompile "javax.servlet:servlet-api:2.5"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.hamcrest:hamcrest:2.2"
+    testImplementation "org.mockito:mockito-core:4.9.0"
+    testImplementation "jakarta.servlet:jakarta.servlet-api:6.0.0"
 }
 
 jacocoTestReport {
@@ -81,7 +93,7 @@ clean.doFirst {
 
 // Creates a version.txt file containing the current version of the SDK.
 // This file is picked up and parsed by our Ship Orb to determine the version.
-task exportVersion()  {
+task exportVersion() {
     doLast {
         new File(rootDir, "version.txt").text = "$version"
     }

--- a/lib/src/main/java/com/auth0/spring/security/api/BearerSecurityContextRepository.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/BearerSecurityContextRepository.java
@@ -9,8 +9,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpRequestResponseHolder;
 import org.springframework.security.web.context.SecurityContextRepository;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class BearerSecurityContextRepository implements SecurityContextRepository {
     private final static Logger logger = LoggerFactory.getLogger(BearerSecurityContextRepository.class);

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtAccessDeniedHandler.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtAccessDeniedHandler.java
@@ -4,9 +4,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandlerImpl;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationEntryPoint.java
@@ -4,15 +4,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         response.addHeader(
                 HttpHeaders.WWW_AUTHENTICATE,
                 "Bearer error=\"Invalid access token\""

--- a/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationProvider.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/JwtAuthenticationProvider.java
@@ -18,7 +18,7 @@ import java.security.interfaces.RSAPublicKey;
 
 public class JwtAuthenticationProvider implements AuthenticationProvider {
 
-    private static Logger logger = LoggerFactory.getLogger(JwtAuthenticationProvider.class);
+    private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationProvider.class);
 
     private final byte[] secret;
     private final String[] issuers;

--- a/lib/src/main/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebToken.java
+++ b/lib/src/main/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebToken.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 
 public class PreAuthenticatedAuthenticationJsonWebToken implements Authentication, JwtAuthentication {
 
-    private static Logger logger = LoggerFactory.getLogger(PreAuthenticatedAuthenticationJsonWebToken.class);
+    private static final Logger logger = LoggerFactory.getLogger(PreAuthenticatedAuthenticationJsonWebToken.class);
 
     private final DecodedJWT token;
 

--- a/lib/src/test/java/com/auth0/spring/security/api/BearerSecurityContextRepositoryTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/BearerSecurityContextRepositoryTest.java
@@ -2,14 +2,13 @@ package com.auth0.spring.security.api;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.spring.security.api.authentication.AuthenticationJsonWebToken;
 import com.auth0.spring.security.api.authentication.PreAuthenticatedAuthenticationJsonWebToken;
 import org.junit.Test;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.web.context.HttpRequestResponseHolder;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -18,7 +17,7 @@ import static org.mockito.Mockito.*;
 public class BearerSecurityContextRepositoryTest {
 
     @Test
-    public void shouldDoNothingOnContextSave() throws Exception {
+    public void shouldDoNothingOnContextSave() {
         BearerSecurityContextRepository repository = new BearerSecurityContextRepository();
         SecurityContext context = mock(SecurityContext.class);
         HttpServletRequest request = mock(HttpServletRequest.class);

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtAccessDeniedHandlerTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtAccessDeniedHandlerTest.java
@@ -3,8 +3,8 @@ package com.auth0.spring.security.api;
 import org.junit.Test;
 import org.springframework.security.access.AccessDeniedException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationEntryPointTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/JwtAuthenticationEntryPointTest.java
@@ -3,8 +3,8 @@ package com.auth0.spring.security.api;
 import org.junit.Test;
 import org.springframework.security.core.AuthenticationException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/lib/src/test/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebTokenTest.java
+++ b/lib/src/test/java/com/auth0/spring/security/api/authentication/PreAuthenticatedAuthenticationJsonWebTokenTest.java
@@ -18,7 +18,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
 
 public class PreAuthenticatedAuthenticationJsonWebTokenTest {
 
@@ -27,7 +26,7 @@ public class PreAuthenticatedAuthenticationJsonWebTokenTest {
     private Algorithm hmacAlgorithm;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         hmacAlgorithm = Algorithm.HMAC256("secret");
     }
 


### PR DESCRIPTION
Upgrades the library to be compatible with Spring Security 6.

- Requires Java 17
- Upgrades Gradle to latest, 7.6 (minimum supported is 7.3)
- Upgrades Servlet API to 6, up from 2.5 (From Java EE to Jakarta EE)
- Upgrades other libraries to latest version
- Changes the CI pipeline to use the convenience images from CircleCI, and upgrade to OpenJDK 17

Please notice `jcenter()` was added to the list of repositories. It is deprecated, but so is Bintray.